### PR TITLE
style(ui): Adjust styles and add blurred background to components

### DIFF
--- a/src/components/common/Main.astro
+++ b/src/components/common/Main.astro
@@ -3,7 +3,7 @@
 ---
 
 <main
-  class=" overflow-scroll shadow-2xl rounded-3xl bg-hippie-blue-50 no-scrollbar scroll-smooth"
+  class=" overflow-scroll shadow-2xl rounded-3xl no-scrollbar scroll-smooth"
   :class="showNav ? 'opacity-0' : ''"
   x-transition.opacity
   x-ref="mainContainer"

--- a/src/components/sections/CallToAction.astro
+++ b/src/components/sections/CallToAction.astro
@@ -9,7 +9,7 @@ const { id, buttonText, buttonLink } = Astro.props as Props;
 ---
 
 <section
-  class="bg-matisse text-white py-12 md:py-24"
+  class="bg-matisse text-white py-12 md:py-24 m-12 rounded-xl shadow-xl"
   id={id}
 >
   <div class="container mx-auto px-4 text-center max-w-xl">

--- a/src/components/sections/Feature.astro
+++ b/src/components/sections/Feature.astro
@@ -11,10 +11,12 @@ interface Props {
 const { id, imageUrl, imageAlt, reverse = false } = Astro.props as Props;
 ---
 
-<section class={`py-12 md:py-24 ${reverse ? "" : "bg-white"}`} id={id}>
+<section class="py-12 md:py-24" id={id}>
   <div class="container mx-auto px-8">
     <div
-      class={`flex flex-wrap ${reverse ? "flex-row md:flex-row-reverse" : "flex-row "} items-center justify-center`}
+      class={`flex flex-wrap ${
+        reverse ? "flex-row md:flex-row-reverse" : "flex-row "
+      } items-center justify-center`}
     >
       <div class="w-full md:w-1/2 mb-8 md:mb-0 max-w-lg">
         <h2
@@ -26,14 +28,30 @@ const { id, imageUrl, imageAlt, reverse = false } = Astro.props as Props;
           <slot name="paragraph" />
         </p>
       </div>
-      <div class="w-full md:w-1/2 flex justify-center">
-        {imageUrl && (
-          <img
-            src={imageUrl}
-            alt={imageAlt}
-            class="max-w-xs md:max-w-sm lg:max-w-md w-full h-full aspect-square"
-          />
-        )}
+      <div class="w-full md:w-1/2 flex justify-center relative">
+        <!-- Blurred Background Image -->
+        {
+          imageUrl && (
+            <div class="absolute inset-0 flex justify-center items-center">
+              <img
+                src={imageUrl}
+                alt=""
+                aria-hidden="true"
+                class="blur-lg transform scale-105 max-w-xs md:max-w-sm lg:max-w-md w-full h-full aspect-square"
+              />
+            </div>
+          )
+        }
+        <!-- Original Image -->
+        {
+          imageUrl && (
+            <img
+              src={imageUrl}
+              alt={imageAlt}
+              class="relative z-10 max-w-xs md:max-w-sm lg:max-w-md w-full h-full aspect-square"
+            />
+          )
+        }
       </div>
     </div>
   </div>

--- a/src/components/sections/HeroSection.astro
+++ b/src/components/sections/HeroSection.astro
@@ -1,28 +1,45 @@
 ---
 // HeroSection.astro
 interface Props {
-	imageAlt?: string;
-	imageUrl?: string;
-	buttonText?: string;
-	buttonLink?: string;
+  imageAlt?: string;
+  imageUrl?: string;
+  buttonText?: string;
+  buttonLink?: string;
   id?: string;
 }
 const { imageAlt, imageUrl, buttonText, buttonLink, id } = Astro.props;
 ---
 
 <section
-	class="container mx-auto px-4 py-12 md:py-24 flex flex-wrap-reverse md:flex-wrap items-center md:min-h-full" id={id}
+  class="container mx-auto px-4 py-12 md:py-24 flex flex-wrap-reverse md:flex-wrap items-center md:min-h-full"
+  id={id}
 >
-	<div class="w-full md:w-1/2 flex justify-center mb-8 md:mb-0">
-		<img src={imageUrl} alt={imageAlt} loading="lazy" class="max-w-xs md:max-w-sm lg:max-w-md w-full h-full aspect-square px-6" />
-	</div>
-	<div class="w-full md:w-1/2 text-center md:text-left text-matisse max-w-xl pb-12 md:py-0">
-		<h1 class="text-3xl md:text-4xl lg:text-5xl font-bold mb-6"><slot name="header" /></h1>
-		<p class="text-xl md:text-2xl mb-8 text-rhino"><slot /></p>
-		<a
-			href={buttonLink}
-			class="inline-block bg-matisse text-white text-bold text-lg md:text-xl font-bold py-2 px-6 rounded-full hover:bg-apricot transition duration-300"
-			>{buttonText}</a
-		>
-	</div>
+  <div class="w-full md:w-1/2 flex justify-center mb-8 md:mb-0 relative">
+    <!-- Blurred Image as Background -->
+    <img
+      src={imageUrl}
+      alt=""
+      aria-hidden="true"
+      class="absolute max-w-xs md:max-w-sm lg:max-w-md w-full h-full aspect-square px-6 -z-10 blur-lg transform scale-105"
+    />
+    <!-- Original Image -->
+    <img
+      src={imageUrl}
+      alt={imageAlt}
+      class="max-w-xs md:max-w-sm lg:max-w-md w-full h-full aspect-square px-6 z-0"
+    />
+  </div>
+  <div
+    class="w-full md:w-1/2 text-center md:text-left text-matisse max-w-xl pb-12 md:py-0"
+  >
+    <h1 class="text-3xl md:text-4xl lg:text-5xl font-bold mb-6">
+      <slot name="header" />
+    </h1>
+    <p class="text-xl md:text-2xl mb-8 text-rhino"><slot /></p>
+    <a
+      href={buttonLink}
+      class="inline-block bg-matisse text-white text-bold text-lg md:text-xl font-bold py-2 px-6 rounded-full hover:bg-apricot transition duration-300"
+      >{buttonText}</a
+    >
+  </div>
 </section>

--- a/src/components/sections/LogoGrid.astro
+++ b/src/components/sections/LogoGrid.astro
@@ -5,7 +5,7 @@ interface Props {
 const { id } = Astro.props;
 ---
 
-<section class="container mx-auto px-4 py-12 text-center bg-white" id={id}>
+<section class="container mx-auto px-4 py-12 text-center" id={id}>
   <h2 class="text-2xl md:text-3xl lg:text-4xl font-bold mb-6 text-matisse">
     <slot name="heading" />
   </h2>


### PR DESCRIPTION
This commit includes changes to various component styles. Specifically, it removes the bg-hippie-blue-50 class from Main.astro, adds margin, rounded and shadow classes to CallToAction.astro, removes a conditional bg-white class from Feature.astro and restructures the layout with an addition of a blurred background image. It also modifies HeroSection.astro by adding a blurred image as background and adjusts indentation, and undoes the bg-white class in LogoGrid.astro.