### PR TITLE
feat(ui): enhance main and navigation component styles

### DIFF
--- a/src/components/common/Main.astro
+++ b/src/components/common/Main.astro
@@ -3,7 +3,7 @@
 ---
 
 <main
-  class=" overflow-scroll shadow-2xl rounded-3xl no-scrollbar scroll-smooth"
+  class=" overflow-scroll shadow-2xl rounded-3xl no-scrollbar scroll-smooth transition-opacity"
   :class="showNav ? '' : ''"
   x-transition.opacity
   x-ref="mainContainer"

--- a/src/components/common/Navigation.astro
+++ b/src/components/common/Navigation.astro
@@ -19,7 +19,7 @@ const navLinks: NavLink[] = Astro.props.navLinks;
   x-transition:leave-end="opacity-0 bg-opacity-0"
   @click="showNav = false"
   :style="navStyle"
-  :class="showNav ? 'opacity-100' : 'opacity-0 hidden'"
+  :class="showNav ? '' : 'hidden'"
   class="absolute z-50 overflow-auto px-10 rounded-3xl bg-hippie-blue h-auto bg-opacity-50 backdrop-blur-lg"
 >
   <ul
@@ -28,7 +28,7 @@ const navLinks: NavLink[] = Astro.props.navLinks;
     {
       navLinks.map((link) => (
         <li class="justify-center flex">
-          <a class="p-4 text-center uppercase text-2xl text-rhino flex hover:bg-white rounded-full transition-colors w-fit" href={link.href}>
+          <a class="py-6 px-12 text-center uppercase text-2xl text-rhino flex hover:bg-white hover:bg-opacity-30 rounded-full transition-colors w-fit" href={link.href}>
             {link.text}
           </a>
         </li>


### PR DESCRIPTION
This commit updates the styling of the Main and Navigation components. The 'Main' component now includes a transition-opacity effect for smoother visibility changes. The 'Navigation' component has simplified logic for toggling visibility and improved styling of navigation links, including padding adjustments and background opacity changes on hover, for better user experience.