### PR TITLE
feat(Navigation): improve hide/show animation for navigation component

### DIFF
--- a/src/components/common/Navigation.astro
+++ b/src/components/common/Navigation.astro
@@ -19,8 +19,8 @@ const navLinks: NavLink[] = Astro.props.navLinks;
   x-transition:leave-end="opacity-0 bg-opacity-0"
   @click="showNav = false"
   :style="navStyle"
-  :class="showNav ? '' : 'hidden'"
-  class="absolute z-50 overflow-auto px-10 rounded-3xl bg-hippie-blue h-auto bg-opacity-50 backdrop-blur-lg"
+  :class="showNav ? '' : 'opacity-0 -z-50'"
+  class="absolute z-50 overflow-auto px-10 rounded-3xl bg-hippie-blue h-auto bg-opacity-50 backdrop-blur-lg transition-all"
 >
   <ul
     class="flex grow-1 flex-col h-full w-full justify-center content-center gap-0 font-display"


### PR DESCRIPTION
In this commit, we updated the Navigation component to use CSS transitions for hiding and showing the menu instead of toggling visibility. This improves the smoothness and look of the navigation experience. The CSS classes 'hidden' and 'opacity-0 -z-50' are now used to hide the navigation menu with a fade out effect, and 'transition-all' has been added to animate all changing properties.